### PR TITLE
Added FAQ templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 📋 Changelog for "LOOPIS Theme"
+## 0.81 (2026-03-09)
+- Added two new templates for FAQ: archive-faq.php and single-faq.php for CPT faq.
+- Added two experimental templates for /faq-tag/ : page-faq-tag.php and /faq-tag/tag/ : taxonomy-faq-tag.php
+- page-faq-tag.php needs to be set in an empty page with slug "faq-tag" in order to work
 
 ## 0.80 (beta)
 - Preparing for migration of FAQ pages to FAQ posts.

--- a/archive-faq.php
+++ b/archive-faq.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Content for page using url /faqs
+ * 
+ * Lists faq posts.
+ */
+
+get_header(); ?>
+
+<div class="content">
+	<div class="page-padding">
+
+<h1>💡 Frågor & svar</h1>
+<hr>
+<p class="small">💡 Vanliga frågor och info om LOOPIS.</p>
+
+<p>Undrar du något? Här finns svar på det mesta.</p>
+<?php if ( is_user_logged_in() ) : ?>
+<p class="small">🛟 Har du problem med en annons? Använd formuläret längst ner på annonssidan!</p>
+<p class="small">💭 Du kan också skicka frågor och feedback till admin längst ner.</p>
+<?php endif; ?>
+
+<h3>Instruktioner</h3>
+<hr>
+<p><span class="big-link"><a href="/faq/hur-funkar-loopis">📌 Hur funkar LOOPIS?</a></span></p>
+<p><span class="big-link"><a href="/faq/hur-far-jag-saker">📌 Hur får jag saker?</a></span></p>
+<p><span class="big-link"><a href="/faq/hur-ger-jag-saker/">📌 Hur ger jag saker?</a></span></p>
+<p><span class="big-link"><a href="/faq/tips-hemskarm">📌 Lägg LOOPIS på din hemskärm</a></span></p>
+
+<?php if ( is_user_logged_in() ) : ?>
+<p><span class="big-link"><a href="/faq/kop-mynt">💰 Köp regnbågsmynt</a></span></p>
+<?php endif; ?>
+
+<h3>Medlemskap</h3>
+<hr>
+<p><span class="big-link"><a href="/faq/varfor-medlemskap">📌 Varför måste jag vara medlem?</a></span></p>
+<p><span class="big-link"><a href="/faq/varfor-bagis">📌 Varför måste jag bo i Bagis?</a></span></p>
+<p><span class="big-link"><a href="/faq/tips-till-ny-medlem">📌 Tips till ny medlem</a></span></p>
+
+<?php if ( current_user_can('member_earlier')) { ?>
+	<p><span class="big-link"><a href="../fornya-medlemskap">📋 Förnya medlemskap</a></span></p>
+<?php } else { ?>
+	<p><span class="big-link"><a href="../register">📋 Bli medlem</a></span></p>
+<?php } ?>
+
+<h3>LOOPIS.app</h3>
+<hr>
+<p><span class="big-link"><a href="/faq/hur-funkar-lottning">📌 Hur funkar lottning?</a></span></p>
+<p><span class="big-link"><a href="/faq/hur-funkar-regnbagsmynt">📌 Hur funkar regnbågsmynt?</a></span></p>
+<p><span class="big-link"><a href="/faq/hur-funkar-beloningar/">📌 Hur funkar belöningar?</a></span></p>
+<p><span class="big-link"><a href="/faq/restriktioner">📌 Vilka annonser är inte tillåtna?</a></span></p>
+
+
+<h3>LOOPIS skåp</h3>
+<hr>
+<p><span class="big-link"><a href="/faq/hur-funkar-skapet">📌 Hur funkar skåpet?</a></span></p>
+<p><span class="big-link"><a href="/faq/saker-som-inte-ryms-i-skapet">📌 Saker som inte ryms i skåpet?</a></span></p>
+
+<h3>Om föreningen</h3>
+<hr>
+<p><span class="big-link"><a href="/faq/vad-ar-loopis">📌 Vad är LOOPIS?</a></span></p>
+<p><span class="big-link"><a href="/faq/kontakt">📌 Kontakt med föreningen</a></span></p>
+<p><span class="big-link"><a href="/faq/hjalpa-till">📌 Hur kan jag hjälpa till?</a></span></p>
+<p><span class="big-link"><a href="/faq/max-murpos">📌 Vem är Max Murpos?</a></span></p>
+<p><span class="big-link"><a href="stadgar">📜 Föreningens stadgar</a></span></p>
+<p><span class="big-link"><a href="../privacy">🗄 Integritetspolicy</a></span></p>
+
+<?php if ( is_user_logged_in() ) : ?>
+<h3>För medlemmar</h3>
+<hr>
+<p><span class="big-link"><a href="https://drive.google.com/drive/folders/1l1B43flky-zXgQ2wFD24s_32N_pfWHvd?usp=drive_link"><i class="fas fa-share"></i> Föreningens protokoll</a></span></p>
+<p><span class="big-link"><a href="https://www.facebook.com/groups/loopis" target="_blank" rel="noreferrer noopener"><i class="fas fa-share"></i> Facebook-grupp</a></span></p>
+<?php endif; ?>
+
+<div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
+
+<div class="wrapped">
+<h5>⚠ Fler frågor?</h5>
+<hr>
+<?php if ( is_user_logged_in() ) { ?>
+<p>→ Fråga i medlemmarnas <a rel="noreferrer noopener" href="https://web.facebook.com/groups/loopis.medlemmar" target="_blank">Facebook-grupp</a></p>
+<p>→ Skicka en fråga eller feedback till admin i formuläret här nedanför.</p>
+<?php } ?>
+<p>→ Maila styrelsen på <a rel="noreferrer noopener" href="mailto:info@loopis.org" target="_blank">info@loopis.org</a></p>
+</div>
+
+</div><!--page-padding-->
+</div><!--content-->
+
+<?php get_footer(); ?>

--- a/page-faq-tag.php
+++ b/page-faq-tag.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Content for page using url /faq-tag/
+ * 
+ */
+
+get_header(); ?>
+
+<div class="content">
+	<div class="page-padding">
+
+<h1>💡 Frågor & svar - <?php the_title(); ?></h1>
+<hr>
+<p class="small">💡 Vanliga frågor och info om LOOPIS.</p>
+
+<p>Undrar du något? Här finns svar på det mesta.</p>
+<?php if ( is_user_logged_in() ) : ?>
+<p class="small">🛟 Har du problem med en annons? Använd formuläret längst ner på annonssidan!</p>
+<p class="small">💭 Du kan också skicka frågor och feedback till admin längst ner.</p>
+<?php endif; ?>
+
+<!-- start list all tags -->
+
+<?php
+$terms = get_terms([
+    'taxonomy'   => 'faq-tag',
+    'hide_empty' => false,
+]);
+
+if (!empty($terms) && !is_wp_error($terms)) :
+
+    foreach ($terms as $term) : ?>
+
+        <section class="faq-tag-section">
+            <h2>
+                <a href="<?php echo esc_url(get_term_link($term)); ?>">
+                    <?php echo esc_html($term->name); ?>
+                </a>
+            </h2>
+
+            <?php
+            $faq_query = new WP_Query([
+                'post_type'      => 'faq',
+                'posts_per_page' => -1, // show all posts
+                'tax_query'      => [
+                    [
+                        'taxonomy' => 'faq-tag',
+                        'field'    => 'term_id',
+                        'terms'    => $term->term_id,
+                    ],
+                ],
+            ]);
+
+            if ($faq_query->have_posts()) :
+
+                echo '<ul>';
+
+                while ($faq_query->have_posts()) :
+                    $faq_query->the_post();
+                    echo '<li><a href="' . esc_url(get_permalink()) . '">' . esc_html(get_the_title()) . '</a></li>';
+                endwhile;
+
+                echo '</ul>';
+
+                wp_reset_postdata();
+
+            else :
+                echo '<p>Inga FAQ i denna tag.</p>';
+            endif;
+            ?>
+
+        </section>
+
+    <?php endforeach;
+
+else :
+    echo '<p>Inga tags hittades.</p>';
+endif;
+?>
+
+<?php
+// Reset postdata
+wp_reset_postdata();
+?>
+
+<!-- end list all tags -->
+
+<!-- tag cloud -->
+
+<hr>
+<h2>Taggmoln</h2>
+<?php
+wp_tag_cloud([
+    'taxonomy'   => 'faq-tag',  // What taxonomy
+    'smallest'   => 12,          // Min font-size in px
+    'largest'    => 24,          // Max font-size in px
+    'unit'       => 'px',
+    'format'     => 'flat',      // 'flat', 'list', or 'array'
+    'separator'  => " ",         // separator between tags
+    'orderby'    => 'count',     // sort by count
+    'order'      => 'DESC',      // the biggest first
+    'number'     => 0,           // 0 = all terms
+]);
+?>
+
+<!-- end tag cloud -->
+
+<div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
+
+<div class="wrapped">
+<h5>⚠ Fler frågor?</h5>
+<hr>
+<?php if ( is_user_logged_in() ) { ?>
+<p>→ Fråga i medlemmarnas <a rel="noreferrer noopener" href="https://web.facebook.com/groups/loopis.medlemmar" target="_blank">Facebook-grupp</a></p>
+<p>→ Skicka en fråga eller feedback till admin i formuläret här nedanför.</p>
+<?php } ?>
+<p>→ Maila styrelsen på <a rel="noreferrer noopener" href="mailto:info@loopis.org" target="_blank">info@loopis.org</a></p>
+</div>
+
+</div><!--page-padding-->
+</div><!--content-->
+
+<?php get_footer(); ?>

--- a/single-faq.php
+++ b/single-faq.php
@@ -1,0 +1,12 @@
+<?php get_header(); ?>
+
+<div class="content">
+<div class="page-padding">
+
+<?php the_content(); ?>
+<div class="clear"></div>
+
+</div><!--page-padding-->
+</div><!--content-->
+
+<?php get_footer(); ?>

--- a/taxonomy-faq-tag.php
+++ b/taxonomy-faq-tag.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Content for page using url /faq-tag/tag
+ * 
+ */
+
+get_header(); ?>
+
+<div class="content">
+	<div class="page-padding">
+
+<h1>💡 Frågor & svar - tag</h1>
+<hr>
+<p class="small">💡 Vanliga frågor och info om LOOPIS.</p>
+
+<p>Undrar du något? Här finns svar på det mesta.</p>
+<?php if ( is_user_logged_in() ) : ?>
+<p class="small">🛟 Har du problem med en annons? Använd formuläret längst ner på annonssidan!</p>
+<p class="small">💭 Du kan också skicka frågor och feedback till admin längst ner.</p>
+<?php endif; ?>
+
+<!-- get specific tags-->
+
+<?php
+// Get the current term object
+$term = get_queried_object();
+
+// Show the term name as h1
+?>
+<header class="taxonomy-header">
+    <h1><?php echo esc_html( $term->name ); ?></h1>
+    <?php if ( ! empty( $term->description ) ) : ?>
+        <div class="term-description">
+            <?php
+            // Show description without extra h2 (using wpautop)
+            echo wpautop( wp_kses_post( $term->description ) );
+            ?>
+        </div>
+    <?php endif; ?>
+</header>
+
+<?php
+// Create a custom WP_Query for FAQ with the current term
+$faq_query = new WP_Query([
+    'post_type' => 'faq',
+    'tax_query' => [
+        [
+            'taxonomy' => 'faq-tag',
+            'field'    => 'slug',
+            'terms'    => $term->slug,
+        ]
+    ],
+    'posts_per_page' => -1, // all posts
+    'orderby'        => 'title', // sort by title
+    'order'          => 'ASC',
+]);
+
+if ( $faq_query->have_posts() ) : ?>
+    <ul class="faq-list">
+        <?php while ( $faq_query->have_posts() ) : $faq_query->the_post(); ?>
+            <li>
+                <a href="<?php echo esc_url( get_permalink() ); ?>">
+                    <?php echo esc_html( get_the_title() ); ?>
+                </a>
+            </li>
+        <?php endwhile; ?>
+    </ul>
+<?php else : ?>
+    <p>Inga FAQ hittades för denna tag.</p>
+<?php endif; ?>
+
+<?php
+// Reset postdata
+wp_reset_postdata();
+?>
+
+<!-- end get specific tag -->
+
+<div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
+
+<div class="wrapped">
+<h5>⚠ Fler frågor?</h5>
+<hr>
+<?php if ( is_user_logged_in() ) { ?>
+<p>→ Fråga i medlemmarnas <a rel="noreferrer noopener" href="https://web.facebook.com/groups/loopis.medlemmar" target="_blank">Facebook-grupp</a></p>
+<p>→ Skicka en fråga eller feedback till admin i formuläret här nedanför.</p>
+<?php } ?>
+<p>→ Maila styrelsen på <a rel="noreferrer noopener" href="mailto:info@loopis.org" target="_blank">info@loopis.org</a></p>
+</div>
+
+</div><!--page-padding-->
+</div><!--content-->
+
+<?php get_footer(); ?>


### PR DESCRIPTION
Added two new templates for FAQ: archive-faq.php and single-faq.php for CPT faq.
Added two experimental templates for /faq-tag/ : page-faq-tag.php and /faq-tag/tag/ : taxonomy-faq-tag.php
page-faq-tag.php needs to be set in an empty page with name/slug "faq-tag" in order to work.