### PR TITLE
fix: correct misplaced closing brace in questions-visitor.php

### DIFF
--- a/templates/faq/questions-visitor.php
+++ b/templates/faq/questions-visitor.php
@@ -6,8 +6,8 @@
  */
 
 if (!defined('ABSPATH')) {
-    }
     exit; // Exit if accessed directly
+}   
 ?>
 
 <div class="columns"><div class="column1"><h5>💡 Vanliga frågor</h5></div>


### PR DESCRIPTION
The closing brace was misplaced, causing `exit;` to execute unconditionally. 

This resulted in the footer being missing on /submit/ page.

Fixes #42